### PR TITLE
Intellij import not failing if publish config does not exist

### DIFF
--- a/logging/publish.gradle.kts
+++ b/logging/publish.gradle.kts
@@ -4,8 +4,8 @@ apply(plugin = "maven-publish")
 apply(plugin = "signing")
 
 // defined in user's global gradle.properties
-val sonatype_username: String by project
-val sonatype_password: String by project
+val sonatype_username: String? by project
+val sonatype_password: String? by project
 
 // defined in project's gradle.properties
 val groupId: String by project


### PR DESCRIPTION
I don't have the values defined so intellij falls over on import. Assuming your publishing script still works with nullables (big if, but I haven't tested it), this makes new user onboarding a bit easier. Feel free to close if uninterested :)