### PR TITLE
Force AtomicReference initialization before KmLogging object on JVM b…

### DIFF
--- a/logging/src/commonMain/kotlin/org/lighthousegames/logging/KmLog.kt
+++ b/logging/src/commonMain/kotlin/org/lighthousegames/logging/KmLog.kt
@@ -1,5 +1,7 @@
 package org.lighthousegames.logging
 
+import logFactory
+
 open class KmLog(tag: String) {
     val tagName = tag
 

--- a/logging/src/commonMain/kotlin/org/lighthousegames/logging/KmLogging.kt
+++ b/logging/src/commonMain/kotlin/org/lighthousegames/logging/KmLogging.kt
@@ -1,14 +1,12 @@
 package org.lighthousegames.logging
 
 import co.touchlab.stately.concurrency.AtomicReference
+import logFactory
 import kotlin.native.concurrent.SharedImmutable
 import kotlin.native.concurrent.ThreadLocal
 
 @SharedImmutable
 private val loggers: AtomicReference<List<Logger>> = AtomicReference(listOf<Logger>(PlatformLogger(FixedLogLevel(Platform::isDebug))))
-
-@SharedImmutable
-internal val logFactory: AtomicReference<LogFactory?> = AtomicReference(null)
 
 @ThreadLocal
 object KmLogging {

--- a/logging/src/commonMain/kotlin/org/lighthousegames/logging/factory.kt
+++ b/logging/src/commonMain/kotlin/org/lighthousegames/logging/factory.kt
@@ -1,0 +1,6 @@
+import co.touchlab.stately.concurrency.AtomicReference
+import org.lighthousegames.logging.LogFactory
+import kotlin.native.concurrent.SharedImmutable
+
+@SharedImmutable
+internal val logFactory: AtomicReference<LogFactory?> = AtomicReference(null)


### PR DESCRIPTION
…y moving to a separate file. Closes #6