### PR TITLE
Add ability to remove logger from list

### DIFF
--- a/logging/src/commonMain/kotlin/org/lighthousegames/logging/KmLogging.kt
+++ b/logging/src/commonMain/kotlin/org/lighthousegames/logging/KmLogging.kt
@@ -55,6 +55,16 @@ object KmLogging {
         setupLoggingFlags()
     }
 
+    /**
+     * Removes loggers. For use by native platforms that cannot use the vararg setLoggers.
+     */
+    fun removeLogger(logger: Logger) {
+        val list = ArrayList(loggers.get())
+        list.remove(logger)
+        loggers.set(list)
+        setupLoggingFlags()
+    }
+
     /*
      * Convenience method that sets the log level of the PlatformLogger if there is one.
      */


### PR DESCRIPTION
### Introduction:
This pull request addresses a specific use case where short-lived loggers are required. The current limitation of the library is that custom loggers once added cannot be removed, hindering scenarios where temporary logging is needed.

### Problem Statement:
Currently library lacks the capability to remove custom loggers, making it challenging for users who require short-lived logging instances.

### Proposed Solution:
I have enhanced the library to include the ability to remove custom loggers. This improvement provides users with the flexibility to manage loggers dynamically, especially in scenarios where logging is needed for a specific duration.

### Use Case Example:
Consider an application facilitating money transfers. With the new feature, a custom logger can be created for a single transfer and removed once the transaction is completed. This ensures that logs are concise and relevant, aiding in troubleshooting and error analysis.

### Benefits:
- Improved resource management by allowing the removal of unnecessary loggers.
- Enhanced adaptability to diverse logging requirements.
- Cleaner code with the ability to dynamically manage loggers as needed.