### PR TITLE
Update Dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,14 +11,14 @@ plugins {
 
 allprojects {
     tasks.withType(JavaCompile::class.java).configureEach {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).configureEach {
         compilerOptions {
             compilerOptions {
-                jvmTarget.set(JvmTarget.JVM_11)
+                jvmTarget.set(JvmTarget.JVM_17)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,33 +1,33 @@
 [versions]
-agp = "8.5.2"
-android-compileSdk = "34"
+agp = "8.11.0"
+android-compileSdk = "36"
 android-minSdk = "24"
-android-targetSdk = "34"
-androidx-activityCompose = "1.9.3"
-androidx-appcompat = "1.7.0"
-androidx-constraintlayout = "2.2.0"
-androidx-core-ktx = "1.15.0"
-androidx-lifecycle = "2.8.4"
+android-targetSdk = "36"
+androidx-activityCompose = "1.10.1"
+androidx-appcompat = "1.7.1"
+androidx-constraintlayout = "2.2.1"
+androidx-core-ktx = "1.17.0"
+androidx-lifecycle = "2.9.3"
 androidx-material = "1.12.0"
-compose-multiplatform = "1.7.0"
+compose-multiplatform = "1.8.2"
 dokka = "2.0.0"
-firebaseBom = "33.9.0"
-kotlin = "2.0.21"
-kotlinx-coroutines = "1.9.0"
-kotlinxCoroutinesAndroid = "1.5.0"
-kotlinxDatetime = "0.6.2"
-lifecycleRuntimeKtx = "2.4.0"
-logback = "1.5.16"
-slf4jApi = "2.0.16"
+firebaseBom = "34.2.0"
+kotlin = "2.2.10"
+kotlinx-coroutines = "1.10.2"
+kotlinxCoroutinesAndroid = "1.10.2"
+kotlinxDatetime = "0.7.1"
+lifecycleRuntimeKtx = "2.9.3"
+logback = "1.5.18"
+slf4jApi = "2.0.17"
 statelyConcurrency = "2.1.0"
 logging = "2.0.3"
 
 [libraries]
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics-ktx" }
+firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
-firebase-config-ktx = { module = "com.google.firebase:firebase-config-ktx" }
-firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-ktx" }
+firebase-config-ktx = { module = "com.google.firebase:firebase-config" }
+firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-ktx" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -68,6 +68,12 @@ kotlin {
 
         val jsMain by getting
         val wasmJsMain by getting
+
+      all {
+        languageSettings.apply {
+          optIn("kotlin.time.ExperimentalTime")
+        }
+      }
     }
 }
 

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
         publishLibraryVariants("release")
     }
@@ -79,15 +79,15 @@ kotlin {
 
 android {
     namespace = "com.diamondedge.core"
-    compileSdk = 34
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdk = 21
+        minSdk = libs.versions.android.minSdk.get().toInt()
         consumerProguardFiles("proguard.txt")
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     testOptions {
         unitTests {

--- a/logging/src/commonMain/kotlin/com/diamondedge/logging/PrintLogger.kt
+++ b/logging/src/commonMain/kotlin/com/diamondedge/logging/PrintLogger.kt
@@ -1,6 +1,6 @@
 package com.diamondedge.logging
 
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 class PrintLogger(logLevel: LogLevelController) : Logger, LogLevelController by logLevel {
 

--- a/logging/src/wasmJsMain/kotlin/com/diamondedge/logging/Platform.kt
+++ b/logging/src/wasmJsMain/kotlin/com/diamondedge/logging/Platform.kt
@@ -1,6 +1,6 @@
 package com.diamondedge.logging
 
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 internal actual fun getPlatform(): PlatformApi = WasmPlatform()
 

--- a/logging/src/wasmJsMain/kotlin/com/diamondedge/logging/PlatformLogger.kt
+++ b/logging/src/wasmJsMain/kotlin/com/diamondedge/logging/PlatformLogger.kt
@@ -1,6 +1,6 @@
 package com.diamondedge.logging
 
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 internal actual fun getLoggerApi(): PlatformLoggerApi = WasmPlatformLogger()
 

--- a/sampleApp/composeApp/build.gradle.kts
+++ b/sampleApp/composeApp/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
     }
 
@@ -109,8 +109,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     testOptions {
         unitTests {

--- a/sampleApp/composeApp/build.gradle.kts
+++ b/sampleApp/composeApp/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        moduleName = "composeApp"
+      outputModuleName.set("composeApp")
         browser {
             val rootDirPath = project.rootDir.path
             val projectDirPath = project.projectDir.path

--- a/sampleApp/composeApp/src/androidMain/kotlin/com/diamondedge/sample/App.kt
+++ b/sampleApp/composeApp/src/androidMain/kotlin/com/diamondedge/sample/App.kt
@@ -6,10 +6,10 @@ import com.diamondedge.logging.Log
 import com.diamondedge.logging.PlatformLogger
 import com.diamondedge.logging.VariableLogLevel
 import com.diamondedge.logging.logging
-import com.google.firebase.ktx.Firebase
-import com.google.firebase.remoteconfig.ktx.get
-import com.google.firebase.remoteconfig.ktx.remoteConfig
-import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
+import com.google.firebase.Firebase
+import com.google.firebase.remoteconfig.get
+import com.google.firebase.remoteconfig.remoteConfig
+import com.google.firebase.remoteconfig.remoteConfigSettings
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch


### PR DESCRIPTION
This library is no longer compatible with the latest kotlinx.datetime since there are conflicts and deprecated time classes.

Changes:
- Update to gradle 8.13
- Update to latest android target and agp (supported by intellij)
- Update all androidx dependencies to latest
  - Updated to use new `Clock` namespace in kotlin stdlib
- Update compose
- Update firebase
  - Updated to use new namespaces without `ktx`
- Android min is 24 (why did it differ from the sample app?)
- Update kotlin to 2.2.10
  - New required jvm min is 17

Resolves https://github.com/DiamondEdge1/KmLogging/issues/29